### PR TITLE
Fix syntax error in the DB creation files.

### DIFF
--- a/easyblue_1.2.0/easyblue_1.2.0/assets/sql/data.sql
+++ b/easyblue_1.2.0/easyblue_1.2.0/assets/sql/data.sql
@@ -23,7 +23,7 @@ INSERT INTO `ea_settings` (`name`, `value`) VALUES
 	('conf_notice', 'no'),
 	('google_sync_notice', 'no'),
 	('google_sync_from', ''),
-	('google_sync_to', '')
+	('google_sync_to', '');
 
 INSERT INTO `ea_cellcarrier` (`id`, `cellco`, `cellurl`) VALUES
 	(1, 'Bell', '@txt.bell.ca'),  

--- a/easyblue_1.2.1/assets/sql/data.sql
+++ b/easyblue_1.2.1/assets/sql/data.sql
@@ -24,7 +24,7 @@ INSERT INTO `ea_settings` (`name`, `value`) VALUES
 	('google_sync_notice', 'no'),
 	('google_sync_from', ''),
 	('google_sync_to', ''),
-	('wp_invoice','no')
+	('wp_invoice','no');
 
 INSERT INTO `ea_cellcarrier` (`id`, `cellco`, `cellurl`) VALUES
 	(1, 'Bell', '@txt.bell.ca'),  


### PR DESCRIPTION
Hi Craig,

In your commits db8046c9f8c2f525fee8abd4cd4557ab792a99f2  and fa9c7b558f8a64afa55167a416f2e78720b562af  you forgot a semicolon  in the sql files creating the databases when running EasyBlue - for both 1.2.0 and 1.2.1 versions.

Here is the fix.

HIH