### PR TITLE
Fix display of breaks in the backend.

### DIFF
--- a/easyblue_1.2.0/easyblue_1.2.0/assets/js/backend_calendar_default_view.js
+++ b/easyblue_1.2.0/easyblue_1.2.0/assets/js/backend_calendar_default_view.js
@@ -769,9 +769,14 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
             if (filterType === FILTER_TYPE_PROVIDER && calendarView !== 'month') {
                 $.each(GlobalVariables.availableProviders, function(index, provider) {
                     if (provider['id'] == recordId) {
-                        var workingPlan = jQuery.parseJSON(provider.settings.working_plan);
+                        var workingPlan={};
+                        var workingPlanBulk = jQuery.parseJSON(provider.settings.working_plan);
                         var unavailablePeriod;
 
+                        // Sort the working plan starting with the first day as set in General settings to correctly align breaks in the calendar display
+                        var fDaynum = GeneralFunctions.getWeekDayId(GlobalVariables.weekStartson);
+                        workingPlan = GeneralFunctions.sortWeekDict(workingPlanBulk,fDaynum);
+                        
                         switch(calendarView) {
                             case 'agendaDay':
                                 var selDayName = $calendar.fullCalendar('getView')
@@ -1017,35 +1022,8 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
 
 
         var defaultView = window.innerWidth < 468 ? 'agendaDay' : 'agendaWeek';
-		var fDaynum;
 		var fDay = GlobalVariables.weekStartson;
-
-		switch(fDay) {
-			case "sunday":
-				fDaynum = 0;
-				break;
-			case "monday":
-				fDaynum = 1;
-				break;
-			case "tuesday":
-				fDaynum = 2;
-				break;
-			case "wednesday":
-				fDaynum = 3;
-				break;
-			case "thursday":
-				fDaynum = 4;
-				break;
-			case "friday":
-				fDaynum = 5;
-				break;
-			case "saturday":
-				fDaynum = 6;
-				break;
-			default:
-				fDaynum = 0;
-				break;
-		}		
+                var fDaynum = GeneralFunctions.getWeekDayId(fDay);
 
 		var timeFormat;
         switch(GlobalVariables.timeFormat) {

--- a/easyblue_1.2.0/easyblue_1.2.0/assets/js/general_functions.js
+++ b/easyblue_1.2.0/easyblue_1.2.0/assets/js/general_functions.js
@@ -453,4 +453,125 @@ window.GeneralFunctions = window.GeneralFunctions || {};
         return result;
     };
 
+    /**
+     * Get the Id of a Weekday using the US week format and day names (Sunday=0) as used in the JS code of the appli, case insensitive, short and long names supported.
+     *
+     * @param {String} weekDayName The weekday name amongs Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday.
+
+     * @return {Integer} Returns the ID of the weekday.
+     */
+    exports.getWeekDayId = function (weekDayName) {
+        var result;
+
+        switch (weekDayName.toLowerCase()) {
+
+            case 'sunday':
+            case 'sun':
+                result = 0;
+                break;
+
+            case 'monday':
+            case 'mon':
+                result = 1;
+                break;
+
+            case 'tuesday':
+            case 'tue':
+                result = 2;
+                break;
+
+            case 'wednesday':
+            case 'wed':
+                result = 3;
+                break;
+
+            case 'thursday':
+            case 'thu':
+                result = 4;
+                break;
+
+            case 'friday':
+            case 'fri':
+                result = 5;
+                break;                
+
+            case 'saturday':
+            case 'sat':
+                result = 6;
+                break;                
+                
+            default:
+                throw new Error('Invalid weekday name provided!', weekDayName);
+        }
+
+        return result;
+    };
+
+    /**
+     * Get the name in lowercase of a Weekday using its Id.
+     *
+     * @param {Integer} weekDayId The Id (From 0 for sunday to 6 for saturday).
+
+     * @return {String} Returns the name of the weekday.
+     */
+    exports.getWeekDayName = function (weekDayId) {
+        var result;
+
+        switch (weekDayId) {
+
+            case 0:
+                result = 'sunday';
+                break;
+
+            case 1:
+                result = 'monday';
+                break;
+
+            case 2:
+                result = 'tuesday';
+                break;
+
+            case 3:
+                result = 'wednesday';
+                break;
+
+            case 4:
+                result = 'thursday';
+                break;
+
+            case 5:
+                result = 'friday';
+                break;                
+
+            case 6:
+                result = 'saturday';
+                break;                
+                
+            default:
+                throw new Error('Invalid weekday Id provided!', weekDayId);
+        }
+
+        return result;
+    };
+
+    /**
+     * Sort a dictionary where keys are weekdays
+     *
+     * @param {Object} weekDict A dictionnary with weekdays as keys.
+     * @param {Integer} startDayId Id of the first day to start sorting (From 0 for sunday to 6 for saturday).
+
+     * @return {Object} Returns a sorted dictionary
+     */
+    exports.sortWeekDict = function (weekDict, startDayId) {
+        var sortedWeekDict={};
+
+        for (var i = startDayId; i < startDayId+7; i++)
+        {
+            var weekDayname = GeneralFunctions.getWeekDayName(i%7);
+            sortedWeekDict[weekDayname] = weekDict[weekDayname];
+        }
+        
+        return sortedWeekDict;
+    };
+
 })(window.GeneralFunctions);

--- a/easyblue_1.2.0/easyblue_1.2.0/assets/js/working_plan.js
+++ b/easyblue_1.2.0/easyblue_1.2.0/assets/js/working_plan.js
@@ -45,7 +45,11 @@
      * @param {Object} workingPlan Contains the working hours and breaks for each day of the week.
      */
     WorkingPlan.prototype.setup = function(workingPlan) {
-        $.each(workingPlan, function(index, workingDay) {
+
+        // Always displaying breaks with Sunday as the first day to be consistent with what is done in the the working plan view.
+        var workingPlanSorted = GeneralFunctions.sortWeekDict(workingPlan,0); // 0 is the ID for Sunday
+        
+        $.each(workingPlanSorted, function(index, workingDay) {
             if (workingDay != null) {
                 $('#' + index).prop('checked', true);
                 $('#' + index + '-start').val(workingDay.start);

--- a/easyblue_1.2.1/assets/js/backend_calendar_default_view.js
+++ b/easyblue_1.2.1/assets/js/backend_calendar_default_view.js
@@ -769,9 +769,14 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
             if (filterType === FILTER_TYPE_PROVIDER && calendarView !== 'month') {
                 $.each(GlobalVariables.availableProviders, function(index, provider) {
                     if (provider['id'] == recordId) {
-                        var workingPlan = jQuery.parseJSON(provider.settings.working_plan);
+                        var workingPlan={};
+                        var workingPlanBulk = jQuery.parseJSON(provider.settings.working_plan);
                         var unavailablePeriod;
 
+                        // Sort the working plan starting with the first day as set in General settings to correctly align breaks in the calendar display
+                        var fDaynum = GeneralFunctions.getWeekDayId(GlobalVariables.weekStartson);
+                        workingPlan = GeneralFunctions.sortWeekDict(workingPlanBulk,fDaynum);
+                        
                         switch(calendarView) {
                             case 'agendaDay':
                                 var selDayName = $calendar.fullCalendar('getView')
@@ -1017,35 +1022,8 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
 
 
         var defaultView = window.innerWidth < 468 ? 'agendaDay' : 'agendaWeek';
-		var fDaynum;
 		var fDay = GlobalVariables.weekStartson;
-
-		switch(fDay) {
-			case "sunday":
-				fDaynum = 0;
-				break;
-			case "monday":
-				fDaynum = 1;
-				break;
-			case "tuesday":
-				fDaynum = 2;
-				break;
-			case "wednesday":
-				fDaynum = 3;
-				break;
-			case "thursday":
-				fDaynum = 4;
-				break;
-			case "friday":
-				fDaynum = 5;
-				break;
-			case "saturday":
-				fDaynum = 6;
-				break;
-			default:
-				fDaynum = 0;
-				break;
-		}		
+                var fDaynum = GeneralFunctions.getWeekDayId(fDay);
 
 		var timeFormat;
         switch(GlobalVariables.timeFormat) {

--- a/easyblue_1.2.1/assets/js/general_functions.js
+++ b/easyblue_1.2.1/assets/js/general_functions.js
@@ -461,4 +461,125 @@ window.GeneralFunctions = window.GeneralFunctions || {};
         return result;
     };
 
+    /**
+     * Get the Id of a Weekday using the US week format and day names (Sunday=0) as used in the JS code of the appli, case insensitive, short and long names supported.
+     *
+     * @param {String} weekDayName The weekday name amongs Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday.
+
+     * @return {Integer} Returns the ID of the weekday.
+     */
+    exports.getWeekDayId = function (weekDayName) {
+        var result;
+
+        switch (weekDayName.toLowerCase()) {
+
+            case 'sunday':
+            case 'sun':
+                result = 0;
+                break;
+
+            case 'monday':
+            case 'mon':
+                result = 1;
+                break;
+
+            case 'tuesday':
+            case 'tue':
+                result = 2;
+                break;
+
+            case 'wednesday':
+            case 'wed':
+                result = 3;
+                break;
+
+            case 'thursday':
+            case 'thu':
+                result = 4;
+                break;
+
+            case 'friday':
+            case 'fri':
+                result = 5;
+                break;                
+
+            case 'saturday':
+            case 'sat':
+                result = 6;
+                break;                
+                
+            default:
+                throw new Error('Invalid weekday name provided!', weekDayName);
+        }
+
+        return result;
+    };
+
+    /**
+     * Get the name in lowercase of a Weekday using its Id.
+     *
+     * @param {Integer} weekDayId The Id (From 0 for sunday to 6 for saturday).
+
+     * @return {String} Returns the name of the weekday.
+     */
+    exports.getWeekDayName = function (weekDayId) {
+        var result;
+
+        switch (weekDayId) {
+
+            case 0:
+                result = 'sunday';
+                break;
+
+            case 1:
+                result = 'monday';
+                break;
+
+            case 2:
+                result = 'tuesday';
+                break;
+
+            case 3:
+                result = 'wednesday';
+                break;
+
+            case 4:
+                result = 'thursday';
+                break;
+
+            case 5:
+                result = 'friday';
+                break;                
+
+            case 6:
+                result = 'saturday';
+                break;                
+                
+            default:
+                throw new Error('Invalid weekday Id provided!', weekDayId);
+        }
+
+        return result;
+    };
+
+    /**
+     * Sort a dictionary where keys are weekdays
+     *
+     * @param {Object} weekDict A dictionnary with weekdays as keys.
+     * @param {Integer} startDayId Id of the first day to start sorting (From 0 for sunday to 6 for saturday).
+
+     * @return {Object} Returns a sorted dictionary
+     */
+    exports.sortWeekDict = function (weekDict, startDayId) {
+        var sortedWeekDict={};
+
+        for (var i = startDayId; i < startDayId+7; i++)
+        {
+            var weekDayname = GeneralFunctions.getWeekDayName(i%7);
+            sortedWeekDict[weekDayname] = weekDict[weekDayname];
+        }
+        
+        return sortedWeekDict;
+    };
+
 })(window.GeneralFunctions);

--- a/easyblue_1.2.1/assets/js/working_plan.js
+++ b/easyblue_1.2.1/assets/js/working_plan.js
@@ -45,7 +45,11 @@
      * @param {Object} workingPlan Contains the working hours and breaks for each day of the week.
      */
     WorkingPlan.prototype.setup = function(workingPlan) {
-        $.each(workingPlan, function(index, workingDay) {
+
+        // Always displaying breaks with Sunday as the first day to be consistent with what is done in the the working plan view.
+        var workingPlanSorted = GeneralFunctions.sortWeekDict(workingPlan,0); // 0 is the ID for Sunday
+        
+        $.each(workingPlanSorted, function(index, workingDay) {
             if (workingDay != null) {
                 $('#' + index).prop('checked', true);
                 $('#' + index + '-start').val(workingDay.start);


### PR DESCRIPTION
Hi Craig,

Because the working plans are stored in the database in a Json structure starting on Sunday, selecting another day to start the week make all the breaks to be wrongly displayed in the backend calendar.

For instance, if I set Monday as the first day of the week:
![company_working_plan](https://user-images.githubusercontent.com/38721222/41861036-796bc494-78a0-11e8-9f83-e17b17896d2d.PNG)

You can see that breaks in green and non-working periods in grey are shifted. **Monday** should be a working day, whereas **Saturday** should not.
![wrong_break_display_calendar](https://user-images.githubusercontent.com/38721222/41861085-9db11192-78a0-11e8-9009-928e41d02252.PNG)

With my fix, breaks are correctly displayed:
![correct_break_display_calendar](https://user-images.githubusercontent.com/38721222/41861219-eac1da2a-78a0-11e8-9297-1b62854d7b36.PNG)

The fix consist in sorting the working plan data structure in `backend_calendar_defaultview.js`, starting the sort with the value of `GlobalVariables.weekStartson`.

For the sorting function purpose, I had to perform conversions between weekday names and weekday Ids. Because you had the same needs in the 'Initialize page calendar' code section of `backend_calendar_defaultview.js`, I replaced your switch case by a call of the conversion functions I created. Tee conversion functions are based upon your former switch case code.

In addition I have noticed the same kind of bug on Alex's EA! in the corner case of people migrating from EA! version > 1.3.1 to version 1.3.1. I will propose him a pull request. This is because prior 1.3.1, working plans were stored in DB starting on Monday and now they are stored starting on Sunday.

Because EasyBlue  - as a fork of EA! - may have stored working plans starting on Monday, I added a sort on working plans to always display breaks starting from Sunday in the 'Settings/Business Logic' and 'Users/Providers' tabs. Because Working Plan displays in these tabs start from Sunday (hard-coded html list), I believe it is better to ensure Breaks to be displayed accordingly (i.e. always starting from Sunday).

Hope it helps